### PR TITLE
Control sources and pipewire compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Variable | Description | Type | Default Value
 `arc_fg` | foreground color of the icon arc | string (hex) | "#00ffff"
 `arc_bg` | background color of the icon arc | string (hex) | "#006666"
 `arc_mute` | color of the icon arc when mute | string (hex) | "#ff0000"
-`control_source` | choose to control a audio input | boolean | false
+`device_type` | choose type of pulse device to control (sink or source) | string | "sink"
 
 note: if you set arc_fg but not arc_bg a 60% darker shade of the arc_fg color will be calculated and used for arc_bg
 

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Variable | Description | Type | Default Value
 `arc_fg` | foreground color of the icon arc | string (hex) | "#00ffff"
 `arc_bg` | background color of the icon arc | string (hex) | "#006666"
 `arc_mute` | color of the icon arc when mute | string (hex) | "#ff0000"
+`control_source` | choose to control a audio input | boolean | false
 
 note: if you set arc_fg but not arc_bg a 60% darker shade of the arc_fg color will be calculated and used for arc_bg
 

--- a/gobo/awesome/sound.lua
+++ b/gobo/awesome/sound.lua
@@ -46,7 +46,7 @@ local function update_state(state, output)
 end
 
 local function update(state)
-   update_state(state, pread("pacmd list-sinks"))
+   update_state(state, pread("pacmd list-" .. state.device .. "s"))
 end
 
 local function draw_handle(surface, volume)
@@ -144,6 +144,15 @@ function sound.new(options)
    local arc_fg = options and options.arc_fg or "#00ffff"
    local arc_fg_darker = darken_color(arc_fg)
    local arc_bg = options and options.arc_bg or arc_fg_darker or "#006666"
+   local control_source = options and options.control_source or false
+
+   local pulse_device = ""
+
+   if control_source then
+     pulse_device = "source"
+   else
+     pulse_device = "sink"
+   end
 
    local widget = wibox.widget.imagebox()
    local state = {
@@ -153,7 +162,8 @@ function sound.new(options)
       width = options and options.arc_width or 5,
       color_mute = { gears.color.parse_color(arc_mute) },
       color_fg = { gears.color.parse_color(arc_fg) },
-      color_bg = { gears.color.parse_color(arc_bg) }
+      color_bg = { gears.color.parse_color(arc_bg) },
+      device = pulse_device
    }
 
    widget.set_volume = function (self, val, delta)
@@ -163,13 +173,13 @@ function sound.new(options)
       elseif delta == "-" then
          volume = math.max(0, volume - val)
       end
-      update_state(state, pread("pactl set-sink-volume " .. state.sink .. " " .. volume .. "%; pacmd list-sinks"))
+      update_state(state, pread("pactl set-" .. state.device .. "-volume " .. state.sink .. " " .. volume .. "%; pacmd list-" .. state.device .. "s"))
       update_icon(self, state)
    end
 
    widget.toggle_mute = function(self)
       local setting = state.mute and "no" or "yes"
-      update_state(state, pread("pactl set-sink-mute " .. state.sink .. " " .. setting .. "; pacmd list-sinks"))
+      update_state(state, pread("pactl set-" .. state.device .. "-mute " .. state.sink .. " " .. setting .. "; pacmd list-" .. state.device .. "s"))
       update_icon(self, state)
    end
 

--- a/gobo/awesome/sound.lua
+++ b/gobo/awesome/sound.lua
@@ -21,8 +21,6 @@ end
 
 local function update_state(state, output)
    local active = false
-   state.volume = 0
-   state.mute = false
    for line in output:gmatch("[^\n]+") do
       local k, v = line:match("^%s*([^:]*): (.*)")
          if k == "Volume" then
@@ -39,7 +37,7 @@ local function update_state(state, output)
 end
 
 local function update(state)
-   update_state(state, pread(state.update_cmd))
+   update_state(state, pread(state.get_vol_cmd .. " ; " .. state.get_mute_cmd))
 end
 
 local function draw_handle(surface, volume)
@@ -162,9 +160,10 @@ function sound.new(options)
       color_fg = { gears.color.parse_color(arc_fg) },
       color_bg = { gears.color.parse_color(arc_bg) },
       device = pulse_device,
-      update_cmd = string.format(get_vol_cmd, pulse_device[1], pulse_device[2]) .. ";" .. string.format(get_mute_cmd, pulse_device[1], pulse_device[2]),
-      vol_cmd = string.format(set_vol_cmd, pulse_device[1], pulse_device[2]),
-      mute_cmd = string.format(set_mute_cmd, pulse_device[1], pulse_device[2])
+      get_vol_cmd  = string.format(get_vol_cmd,  pulse_device[1], pulse_device[2]),
+      get_mute_cmd = string.format(get_mute_cmd, pulse_device[1], pulse_device[2]),
+      set_vol_cmd  = string.format(set_vol_cmd,  pulse_device[1], pulse_device[2]),
+      set_mute_cmd = string.format(set_mute_cmd, pulse_device[1], pulse_device[2])
    }
 
 
@@ -175,13 +174,13 @@ function sound.new(options)
       elseif delta == "-" then
          volume = math.max(0, volume - val)
       end
-      update_state(state, pread( state.vol_cmd .. volume .. "% ; " .. state.update_cmd))
+      update_state(state, pread( state.set_vol_cmd .. volume .. "% ; " .. state.get_vol_cmd))
       update_icon(self, state)
    end
 
    widget.toggle_mute = function(self)
       local setting = state.mute and "no" or "yes"
-      update_state(state, pread( state.mute_cmd .. setting .. " ; " .. state.update_cmd))
+      update_state(state, pread( state.set_mute_cmd .. setting .. " ; " .. state.get_mute_cmd))
       update_icon(self, state)
    end
 

--- a/gobo/awesome/sound.lua
+++ b/gobo/awesome/sound.lua
@@ -20,7 +20,6 @@ local function pread(cmd)
 end
 
 local function update_state(state, output)
-   local active = false
    for line in output:gmatch("[^\n]+") do
       local k, v = line:match("^%s*([^:]*): (.*)")
          if k == "Volume" then

--- a/gobo/awesome/sound.lua
+++ b/gobo/awesome/sound.lua
@@ -135,14 +135,14 @@ function sound.new(options)
    local arc_fg = options and options.arc_fg or "#00ffff"
    local arc_fg_darker = darken_color(arc_fg)
    local arc_bg = options and options.arc_bg or arc_fg_darker or "#006666"
-   local control_source = options and options.control_source or false
+   local device_type = options and options.device_type or "sink"
 
    local pulse_device = ""
 
-   if control_source then
-     pulse_device = { "source", "SOURCE" }
-   else
+   if device_type == "sink" then
      pulse_device = { "sink", "SINK" }
+   elseif device_type == "source" then
+     pulse_device = { "source", "SOURCE" }
    end
 
    local get_vol_cmd =  "pactl get-%s-volume @DEFAULT_%s@ "


### PR DESCRIPTION
should have opened this before your most recent commit, will have to resolve conflicts but for now i opened for visibility.

this PR not only adds the abilty to control pulse sources but also makes an important change, instead of parsing the output of pacmd now it parses the output of 2 paclt commands which get the mute or volume of the default sink (or source).

this should make the internal logic a bit simpler i guess on top of giving pipewire support, mind you i have not tested how this behaves with pipewire since my setup still uses pulse.

eventually i would like to migrate this module from using io.popen to use one of the async functions of awesomewm perhaps awful.spawn.with_line_callback but i'm leaving that for another PR